### PR TITLE
enable extracting unbinned contigs to a fasta file

### DIFF
--- a/DAS_Tool
+++ b/DAS_Tool
@@ -56,6 +56,7 @@ function display_help() {
     echo "   --write_bin_evals          Write evaluation for each input bin set [0/1]. (default: 1)"
     echo "   --create_plots             Create binning performance plots [0/1]. (default: 1)"
     echo "   --write_bins               Export bins as fasta files  [0/1]. (default: 0)"
+    echo "   --write_unbinned           Export unbinned contigs as fasta file. Only has an effect when write_bins==1 [0/1]. (default: 0)"
     echo "   --proteins                 Predicted proteins in prodigal fasta format (>scaffoldID_geneNo)."
     echo "                              Gene prediction step will be skipped if given. (optional)"
     echo "   -t, --threads              Number of threads to use. (default: 1)"
@@ -94,6 +95,7 @@ threads=1
 write_bin_evals=1
 create_plots=1
 write_bins=0
+write_unbinned=0
 search_engine="usearch"
 b_weight=0.6
 c_weight=0.5
@@ -121,6 +123,9 @@ while [ "$1" != "" ]; do
                                 ;;
         --write_bins )          shift
                                 write_bins=$1
+                                ;;
+        --write_unbinned )      shift
+                                write_unbinned=$1
                                 ;;
         --proteins )            shift
                                 proteins=$1
@@ -163,6 +168,11 @@ if [ "$write_bins" == "0" ] || [ "$write_bins" == "false" ] || [ "$write_bins" =
 write_bins="FALSE"
 else
 write_bins="TRUE"
+fi
+if [ "$write_unbinned" == "0" ] || [ "$write_unbinned" == "false" ] || [ "$write_unbinned" == "False" ] || [ "$write_unbinned" == "f" ]; then
+write_unbinned="FALSE"
+else
+write_unbinned="TRUE"
 fi
 if [ "$write_bin_evals" == "0" ] || [ "$write_bin_evals" == "false" ] || [ "$write_bin_evals" == "False" ] || [ "$write_bin_evals" == "f" ]; then
 write_bin_evals="FALSE"
@@ -336,9 +346,18 @@ cd $thisdir
 #
 # 5. Extract Bins
 #
+
 if [ "$write_bins" == "TRUE" ]; then
 scaf2bin=$outputbasename\_DASTool_scaffolds2bin.txt
 if test -f $scaf2bin; then
+
+# add unbinned contig names to scaf2bin
+if [ $write_unbinned == "TRUE" ]; then
+grep ">" "$contigs" | tr -d ">" > all_contig_names.txt
+cut -f 1 "$scaf2bin" > DAS_Tool_contig_names.txt
+grep -wf DAS_Tool_contig_names.txt -v all_contig_names.txt | sed 's/$/\tbin.unbinned/g' >> $scaf2bin
+rm all_contig_names.txt DAS_Tool_contig_names.txt
+fi
 
 bin_folder=$outputbasename\_DASTool_bins
 if [ -d "$bin_folder" ]; then


### PR DESCRIPTION
Small modification in the DAS_Tool shell script with an option. Finds names of unbinned contigs, adds them the scaffold2bin file, then extracts them to a file "bin.unbinned"