### PR TITLE
Changed /bin/env to /usr/bin/env in hashbang

### DIFF
--- a/src/Fasta_to_Scaffolds2Bin.sh
+++ b/src/Fasta_to_Scaffolds2Bin.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash 
+#!/usr/bin/env bash 
 
 function display_help() {
     echo " "


### PR DESCRIPTION
I think generally `env` is in `/usr/bin`, rather than `bin`. In any case, it is not on `macOS` or the linux distros I know.