### PR TITLE
ensure dbDirectory has a trailing slash

### DIFF
--- a/src/DAS_Tool.R
+++ b/src/DAS_Tool.R
@@ -343,6 +343,10 @@ dbDirectory <- ifelse(arguments$dbDirectory == 'db',
                        paste0(scriptDir,'/','db/'),
                        arguments$dbDirectory)
 
+# add trailing slash if needed
+if (!endsWith(dbDirectory, '/')) {
+    dbDirectory <- paste0(dbDirectory, '/')
+}
 
 ##
 ## Check files and directories


### PR DESCRIPTION
DAS_Tool.R internally assumes that the `--dbDirectory` argument has been supplied with a trailing slash,
which is not necessarily the case. This PR adds a check, appending the slash if it is missing.