### PR TITLE
Update scg_blank_blast.rb

### DIFF
--- a/src/scg_blank_blast.rb
+++ b/src/scg_blank_blast.rb
@@ -37,7 +37,7 @@ puts "finding SCG candidates..."
 input_blast_database = system "makeblastdb -in #{input_file} -dbtype prot"
 input_blast_out = File.join(output_dir,File.basename(input_file) + ".findSCG.b6")
 abort "makeblastdb did not work for #{input_file}, please check your input file" unless input_blast_database
-input_blast_ok = system "blastp -db #{input_file} -query #{db_name} -outfmt '6 qseqid sseqid pident length qlen slen evalue bitscore' -evalue 0.01 -out #{input_blast_out} -num_threads #{threads}"
+input_blast_ok = system "blastp -db #{input_file} -query #{db_name} -outfmt '6 qseqid sseqid pident length qlen slen evalue bitscore' -evalue 0.01 -out #{input_blast_out} -num_threads #{threads} -max_target_seqs 10000"
 system "rm #{input_file}.psq #{input_file}.pin #{input_file}.phr"
 abort "blast did not work, please check your input file." unless input_blast_ok
 


### PR DESCRIPTION
The default limit of blastp results is 500. In cases where a sample has more than 500 bins this might result in poor performance. The current change should put the limit high enough to cover most cases.